### PR TITLE
Move the db drivers into their own sub-namespace

### DIFF
--- a/src/Drivers/MySqlDb.php
+++ b/src/Drivers/MySqlDb.php
@@ -5,8 +5,11 @@
  * @license MIT
  */
 
-namespace Garden\Db;
+namespace Garden\Db\Drivers;
 
+use Garden\Db\Db;
+use Garden\Db\Identifier;
+use Garden\Db\Literal;
 use PDO;
 
 /**

--- a/src/Drivers/SqliteDb.php
+++ b/src/Drivers/SqliteDb.php
@@ -5,8 +5,11 @@
  * @license MIT
  */
 
-namespace Garden\Db;
+namespace Garden\Db\Drivers;
 
+use Garden\Db\Db;
+use Garden\Db\Identifier;
+use Garden\Db\Literal;
 use PDO;
 
 /**

--- a/tests/MySql/MySqlTestTrait.php
+++ b/tests/MySql/MySqlTestTrait.php
@@ -8,7 +8,7 @@
 namespace Garden\Db\Tests\MySql;
 
 use Garden\Db\Db;
-use Garden\Db\MySqlDb;
+use Garden\Db\Drivers\MySqlDb;
 use PDO;
 
 trait MySqlTestTrait {

--- a/tests/Sqlite/SqliteTestTrait.php
+++ b/tests/Sqlite/SqliteTestTrait.php
@@ -8,7 +8,7 @@
 namespace Garden\Db\Tests\Sqlite;
 
 use Garden\Db\Db;
-use Garden\Db\SqliteDb;
+use Garden\Db\Drivers\SqliteDb;
 use PDO;
 
 trait SqliteTestTrait {


### PR DESCRIPTION
The Db namespace is getting bigger and bigger so I want to make sure it
sticks to the base classes.