### PR TITLE
Fix issue with mediumtext columns

### DIFF
--- a/src/Drivers/MySqlDb.php
+++ b/src/Drivers/MySqlDb.php
@@ -357,7 +357,12 @@ class MySqlDb extends Db {
 
         // Unsigned is represented differently in MySQL.
         $unsigned = !empty($type['unsigned']);
-        unset ($type['unsigned']);
+        unset($type['unsigned']);
+
+        // The max length is not specified for text columns.
+        if (in_array($type['dbtype'], ['tinytext', 'text', 'mediumtext', 'longtext'])) {
+            unset($type['maxLength']);
+        }
 
         $dbType = static::dbType($type).($unsigned ? ' unsigned' : '');
 

--- a/tests/IssueTest.php
+++ b/tests/IssueTest.php
@@ -70,4 +70,26 @@ abstract class IssueTest extends AbstractDbTest {
         $db->insert('null_update', ['id' => 1, 'dt' => new \DateTime('2018-01-01')]);
         $r = $db->update('null_update', ['dt' => null], ['id' => 1]);
     }
+
+    /**
+     * Test creating a column with medium text.
+     */
+    public function testTextCreate() {
+        $tbl = new TableDef('text');
+        $tbl->setPrimaryKey('id')
+            ->setColumn('body0', 'tinytext')
+            ->setColumn('body1', 'text')
+            ->setColumn('body2', 'mediumtext')
+            ->setColumn('body3', 'longtext');
+
+        $tbl->exec(static::$db);
+
+        $tbl->setPrimaryKey('id')
+            ->setColumn('body0', 'longtext')
+            ->setColumn('body1', 'mediumtext')
+            ->setColumn('body2', 'text')
+            ->setColumn('body3', 'tinytext');
+
+        $tbl->exec(static::$db);
+    }
 }


### PR DESCRIPTION
The max length of text columns should not be added to DDL statements and sometimes causes an error.