### PR TITLE
Fix issue when altering a table after a create table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 language: php
 
 php:
-    - 7.0
     - 7.1
     - 7.2
     - 7.3
+    - nightly
 
 sudo: false
 
 matrix:
     fast_finish: true
 
+services:
+    - mysql
+
 install:
     - composer install
-    - composer require phpunit/phpunit ~5
 
 script:
     - ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"vanilla/garden-schema": "^2.0"
 	},
 	"require-dev": {
+		"phpunit/phpunit": "~7",
 		"bobthecow/faker": "dev-master"
 	},
 	"config": {

--- a/src/Db.php
+++ b/src/Db.php
@@ -435,6 +435,11 @@ abstract class Db {
 
         $this->fixIndexes($tableName, $tableDef, $curTable);
 
+        if ($this->tableNames === null) {
+            // Fetch all tables here now so the cache knows all tables that exist.
+            $this->fetchTableNames();
+        }
+
         if (!$curTable) {
             $this->createTableDb($tableDef, $options);
             $this->tables[$tableKey] = $tableDef;
@@ -509,10 +514,6 @@ abstract class Db {
         // Update the cached schema.
         $tableDef['name'] = $tableName;
         $this->tables[$tableKey] = $tableDef;
-
-        if ($this->tableNames === null) {
-            $this->fetchTableNames();
-        }
 
         $this->tableNames[$tableKey] = $tableName;
     }

--- a/tests/IssueTest.php
+++ b/tests/IssueTest.php
@@ -110,4 +110,21 @@ abstract class IssueTest extends AbstractDbTest {
         $this->assertSame(30, $cols['a']['maxLength']);
 
     }
+
+    /**
+     * Tests a bug when altering an existing table after creating a new table.
+     */
+    public function testAlterAfterCreate() {
+        for ($i = 0; $i < 2; $i++) {
+            $tbl1 = new TableDef("table1_$i");
+            $tbl1->setColumn('a', 'varchar(20)');
+            $tbl1->exec(static::$db);
+
+            $tbl2 = new TableDef('table2');
+            $tbl2->setColumn('a', 'varchar(20)');
+            $tbl2->exec(static::$db);
+
+            static::$db->reset();
+        }
+    }
 }

--- a/tests/IssueTest.php
+++ b/tests/IssueTest.php
@@ -53,6 +53,9 @@ abstract class IssueTest extends AbstractDbTest {
         $tbl->exec($db);
 
         $db->insert('null_insert', ['dt' => null]);
+
+        // This test is just to check DB exceptions.
+        $this->assertTrue(true);
     }
 
     /**
@@ -69,6 +72,9 @@ abstract class IssueTest extends AbstractDbTest {
 
         $db->insert('null_update', ['id' => 1, 'dt' => new \DateTime('2018-01-01')]);
         $r = $db->update('null_update', ['dt' => null], ['id' => 1]);
+
+        // This test is just to check DB exceptions.
+        $this->assertTrue(true);
     }
 
     /**
@@ -91,6 +97,9 @@ abstract class IssueTest extends AbstractDbTest {
             ->setColumn('body3', 'tinytext');
 
         $tbl->exec(static::$db);
+
+        // This test is just to check DB exceptions.
+        $this->assertTrue(true);
     }
 
     /**
@@ -126,5 +135,8 @@ abstract class IssueTest extends AbstractDbTest {
 
             static::$db->reset();
         }
+
+        // This test is just to check DB exceptions.
+        $this->assertTrue(true);
     }
 }

--- a/tests/TableDefTest.php
+++ b/tests/TableDefTest.php
@@ -173,6 +173,9 @@ abstract class TableDefTest extends AbstractDbTest {
         $def->exec($db);
 
         $db->insert($tbl, ['a' => 'c']);
+
+        // This test is just to check DB exceptions.
+        $this->assertTrue(true);
     }
 
     public function testTimestampColumn() {
@@ -183,5 +186,8 @@ abstract class TableDefTest extends AbstractDbTest {
             ->setColumn('b', 'timestamp');
 
         $def->exec(self::$db);
+
+        // This test is just to check DB exceptions.
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
Creating a table would set the table name cache to just the one table causing all other table alters to fail.